### PR TITLE
add node inspection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["kedro"]
+dependencies = ["kedro", "typing-extensions"]
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]

--- a/src/kedro_inspect/node.py
+++ b/src/kedro_inspect/node.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import inspect
+from collections import defaultdict
+from copy import deepcopy
+from typing import TYPE_CHECKING, Dict, List, Set
+
+from kedro.pipeline.node import Node as KedroNode
+from typing_extensions import Self, TypedDict
+
+from kedro_inspect.node_func import NodeFunction, NodeFunctionDict
+
+if TYPE_CHECKING:
+    from inspect import BoundArguments
+
+
+class InspectedNodeDict(TypedDict):
+    name: str | None
+    tags: Set[str]
+    confirms: List[str]
+    namespace: str | None
+    inputs: List[str] | Dict[str, str] | str | None
+    outputs: List[str] | Dict[str, str] | str | None
+    function: NodeFunctionDict
+    param_to_input: Dict[str, List[str]]
+
+
+class InspectedNode:
+    def __init__(
+        self,
+        name: str | None,
+        tags: Set[str],
+        confirms: List[str],
+        namespace: str | None,
+        inputs: List[str] | Dict[str, str] | str | None,
+        outputs: List[str] | Dict[str, str] | str | None,
+        function: NodeFunction,
+        param_to_input: Dict[str, List[str]],
+    ) -> None:
+        self.name = name
+        self.tags = tags
+        self.confirms = confirms
+        self.namespace: str | None = namespace
+        self.inputs = inputs
+        self.outputs = outputs
+        self.function = function
+        self.param_to_input = param_to_input
+
+    def to_dict(self) -> InspectedNodeDict:
+        return {
+            "name": self.name,
+            "tags": self.tags,
+            "confirms": self.confirms,
+            "namespace": self.namespace,
+            "inputs": self.inputs,
+            "outputs": self.outputs,
+            "function": self.function.to_dict(),
+            "param_to_input": self.param_to_input,
+        }
+
+    @classmethod
+    def from_dict(cls, dct: InspectedNodeDict) -> Self:
+        return cls(
+            name=dct["name"],
+            tags=dct["tags"],
+            confirms=dct["confirms"],
+            namespace=dct["namespace"],
+            inputs=dct["inputs"],
+            outputs=dct["outputs"],
+            function=NodeFunction.from_dict(dct["function"]),
+            param_to_input=dct["param_to_input"],
+        )
+
+    def to_kedro_node(self) -> KedroNode:
+        return KedroNode(
+            func=self.function.func,
+            inputs=self.inputs,
+            outputs=self.outputs,
+            name=self.name,
+            tags=self.tags,
+            confirms=self.confirms,
+            namespace=self.namespace,
+        )
+
+    @classmethod
+    def from_kedro_node(cls, node: KedroNode) -> Self:
+        return cls(
+            name=node._name,
+            tags=node.tags,
+            confirms=node.confirms,
+            namespace=node._namespace,
+            inputs=deepcopy(node._inputs),
+            outputs=deepcopy(node._outputs),
+            function=NodeFunction.from_callable(node.func),
+            param_to_input=cls.get_param_to_input(node),
+        )
+
+    @staticmethod
+    def get_bound_datasets_from_node(node: KedroNode) -> BoundArguments:
+        sig = inspect.signature(node.func, follow_wrapped=False)
+        return (
+            sig.bind(**node._inputs)
+            if isinstance(node._inputs, dict)
+            else sig.bind(*node.inputs)
+        )
+
+    @staticmethod
+    def get_param_to_input(node: KedroNode) -> Dict[str, List[str]]:
+        bound_datasets = InspectedNode.get_bound_datasets_from_node(node)
+        p_to_ds = defaultdict(list)
+        for param, dataset in bound_datasets.arguments.items():
+            if type(dataset) is tuple:
+                # real_arg is a VAR_POSITIONAL -> multiple datasets can be bound to it
+                p_to_ds[param] = list(dataset)
+            elif type(dataset) is dict:
+                # real_arg is a VAR_KEYWORD -> multiple datasets can be bound to it
+                p_to_ds[param] = list(dataset.values())
+            else:
+                assert type(dataset) is str
+                p_to_ds[param] = [dataset]
+        return p_to_ds

--- a/src/kedro_inspect/node_func.py
+++ b/src/kedro_inspect/node_func.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from inspect import Parameter, _ParameterKind
+from typing import Callable, Dict, List
+
+from typing_extensions import (
+    Any,
+    Self,
+    TypedDict,
+    get_type_hints,
+)
+
+from kedro_inspect.serialisation import fqn_to_obj, obj_to_fqn
+
+
+def get_type_hints_general(func: Callable) -> Dict[str, Any]:
+    # typing.get_type_hints does extra work to get the actual type, whereas
+    #   inspect.signature may return just a string
+    if inspect.isclass(func):
+        # TODO: if TypedDict, then do not use __init__
+        typehints = get_type_hints(func.__init__)
+        typehints["return"] = func
+    else:
+        typehints = get_type_hints(func)
+    return typehints
+
+
+class ArgumentDict(TypedDict):
+    name: str
+    kind: str
+    type_hint: str
+
+
+@dataclass
+class Argument:
+    name: str
+    kind: _ParameterKind
+    type_hint: Any
+
+    def to_dict(self) -> ArgumentDict:
+        return {
+            "name": self.name,
+            "kind": self.kind_to_str(self.kind),
+            "type_hint": obj_to_fqn(self.type_hint),
+        }
+
+    @classmethod
+    def from_dict(cls, dct: ArgumentDict) -> Argument:
+        return cls(
+            name=dct["name"],
+            kind=cls.str_to_kind(dct["kind"]),
+            type_hint=fqn_to_obj(dct["type_hint"]),
+        )
+
+    @staticmethod
+    def kind_to_str(kind: Any) -> str:
+        return {
+            Parameter.POSITIONAL_ONLY: "POSITIONAL_ONLY",
+            Parameter.POSITIONAL_OR_KEYWORD: "POSITIONAL_OR_KEYWORD",
+            Parameter.VAR_POSITIONAL: "VAR_POSITIONAL",
+            Parameter.KEYWORD_ONLY: "KEYWORD_ONLY",
+            Parameter.VAR_KEYWORD: "VAR_KEYWORD",
+        }[kind]
+
+    @staticmethod
+    def str_to_kind(kind_str: str) -> Any:
+        return {
+            "POSITIONAL_ONLY": Parameter.POSITIONAL_ONLY,
+            "POSITIONAL_OR_KEYWORD": Parameter.POSITIONAL_OR_KEYWORD,
+            "VAR_POSITIONAL": Parameter.VAR_POSITIONAL,
+            "KEYWORD_ONLY": Parameter.KEYWORD_ONLY,
+            "VAR_KEYWORD": Parameter.VAR_KEYWORD,
+        }[kind_str]
+
+
+class NodeFunctionDict(TypedDict):
+    func: str
+    parameters: List[ArgumentDict]
+    return_value: str
+
+
+@dataclass
+class NodeFunction:
+    func: Callable
+    parameters: List[Argument]
+    return_value: Any
+
+    @classmethod
+    def from_callable(cls, func: Callable) -> Self:
+        sig = inspect.signature(func, follow_wrapped=False)
+        hints = get_type_hints(func)
+        return cls(
+            func=func,
+            parameters=[
+                Argument(
+                    name=arg.name,
+                    kind=arg.kind,
+                    type_hint=hints.get(arg.name, Any),
+                )
+                for arg in sig.parameters.values()
+            ],
+            return_value=hints.get("return", Any),
+        )
+
+    def to_dict(self) -> NodeFunctionDict:
+        return {
+            "func": obj_to_fqn(self.func),
+            "parameters": [arg.to_dict() for arg in self.parameters],
+            "return_value": obj_to_fqn(self.return_value),
+        }
+
+    @classmethod
+    def from_dict(cls, dct: NodeFunctionDict) -> Self:
+        return cls(
+            func=fqn_to_obj(dct["func"]),
+            parameters=[Argument.from_dict(arg) for arg in dct["parameters"]],
+            return_value=fqn_to_obj(dct["return_value"]),
+        )

--- a/src/kedro_inspect/serialisation.py
+++ b/src/kedro_inspect/serialisation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pydoc
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Any
+
+
+def obj_to_fqn(typ: Any) -> str:
+    return f"{typ.__module__}.{typ.__qualname__}"
+
+
+def fqn_to_obj(fqn: str) -> Any:
+    obj = pydoc.locate(fqn)
+    if obj is None:
+        raise ValueError(f"Could not locate object: {fqn}")
+    return obj

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,42 @@
+from kedro.pipeline import node
+from kedro_inspect.node import InspectedNode
+from kedro_inspect.node_func import NodeFunction
+from typing_extensions import Any
+
+
+def identity(x) -> Any:
+    return x
+
+
+def test_inspected_node() -> None:
+    inputs = ["a"]
+    outputs = ["b"]
+    orig_node = node(identity, inputs, outputs)
+    inspected_node = InspectedNode.from_kedro_node(orig_node)
+
+    assert inspected_node.name is None
+    assert inspected_node.tags == set()
+    assert inspected_node.confirms == []
+    assert inspected_node.namespace is None
+    assert inspected_node.inputs == ["a"]
+    assert inspected_node.outputs == ["b"]
+    assert isinstance(inspected_node.function, NodeFunction)
+    assert inspected_node.param_to_input == {"x": ["a"]}
+
+    kedro_node = inspected_node.to_kedro_node()
+    assert kedro_node == orig_node
+
+    inspected_node_dict = inspected_node.to_dict()
+    assert inspected_node_dict == {
+        "name": None,
+        "tags": set(),
+        "confirms": [],
+        "namespace": None,
+        "inputs": ["a"],
+        "outputs": ["b"],
+        "function": inspected_node.function.to_dict(),
+        "param_to_input": {"x": ["a"]},
+    }
+
+    inspected_node_from_dict = InspectedNode.from_dict(inspected_node_dict)
+    assert inspected_node_from_dict.to_dict() == inspected_node_dict

--- a/tests/test_node_func.py
+++ b/tests/test_node_func.py
@@ -1,0 +1,190 @@
+from inspect import Parameter
+
+from kedro_inspect.node_func import Argument, NodeFunction
+
+
+def dummy_func_w_all_param_types(
+    pos_only: int, /, a: int, b: int, *args: int, kw_only: int, **kwargs: int
+) -> int:
+    """To be used in tests."""
+    return 1
+
+
+def test_argument_to_dict() -> None:
+    arg = Argument(name="foo", kind=Parameter.POSITIONAL_ONLY, type_hint=int)
+    arg_dict = arg.to_dict()
+
+    assert arg_dict == {
+        "name": "foo",
+        "kind": "POSITIONAL_ONLY",
+        "type_hint": "builtins.int",
+    }
+
+
+def test_argument_from_dict() -> None:
+    arg_dict = {"name": "foo", "kind": "POSITIONAL_ONLY", "type_hint": "builtins.int"}
+    arg = Argument.from_dict(arg_dict)
+
+    assert arg.name == "foo"
+    assert arg.kind == Parameter.POSITIONAL_ONLY
+    assert arg.type_hint is int
+
+
+def test_func_from_callable() -> None:
+    """All parameter types are supported."""
+    node_func = NodeFunction.from_callable(dummy_func_w_all_param_types)
+
+    assert node_func.func == dummy_func_w_all_param_types
+    assert len(node_func.parameters) == 6
+
+    pos_only, arg_a, arg_b, args, kw_only, kwargs = node_func.parameters
+    assert isinstance(pos_only, Argument)
+    assert pos_only.name == "pos_only"
+    assert pos_only.kind == Parameter.POSITIONAL_ONLY
+    assert pos_only.type_hint is int
+
+    assert isinstance(arg_a, Argument)
+    assert arg_a.name == "a"
+    assert arg_a.kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert arg_a.type_hint is int
+
+    assert isinstance(arg_b, Argument)
+    assert arg_b.name == "b"
+    assert arg_b.kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert arg_b.type_hint is int
+
+    assert isinstance(args, Argument)
+    assert args.name == "args"
+    assert args.kind == Parameter.VAR_POSITIONAL
+    assert args.type_hint is int
+
+    assert isinstance(kw_only, Argument)
+    assert kw_only.name == "kw_only"
+    assert kw_only.kind == Parameter.KEYWORD_ONLY
+    assert kw_only.type_hint is int
+
+    assert isinstance(kwargs, Argument)
+    assert kwargs.name == "kwargs"
+    assert kwargs.kind == Parameter.VAR_KEYWORD
+    assert kwargs.type_hint is int
+
+    assert node_func.return_value is int
+
+
+def test_func_to_dict() -> None:
+    node_func = NodeFunction.from_callable(dummy_func_w_all_param_types)
+    node_func_dict = node_func.to_dict()
+
+    assert node_func_dict == {
+        "func": "test_node_func.dummy_func_w_all_param_types",
+        "parameters": [
+            {
+                "name": "pos_only",
+                "kind": "POSITIONAL_ONLY",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "a",
+                "kind": "POSITIONAL_OR_KEYWORD",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "b",
+                "kind": "POSITIONAL_OR_KEYWORD",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "args",
+                "kind": "VAR_POSITIONAL",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "kw_only",
+                "kind": "KEYWORD_ONLY",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "kwargs",
+                "kind": "VAR_KEYWORD",
+                "type_hint": "builtins.int",
+            },
+        ],
+        "return_value": "builtins.int",
+    }
+
+
+def test_func_from_dict() -> None:
+    node_func_dict = {
+        "func": "test_node_func.dummy_func_w_all_param_types",
+        "parameters": [
+            {
+                "name": "pos_only",
+                "kind": "POSITIONAL_ONLY",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "a",
+                "kind": "POSITIONAL_OR_KEYWORD",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "b",
+                "kind": "POSITIONAL_OR_KEYWORD",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "args",
+                "kind": "VAR_POSITIONAL",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "kw_only",
+                "kind": "KEYWORD_ONLY",
+                "type_hint": "builtins.int",
+            },
+            {
+                "name": "kwargs",
+                "kind": "VAR_KEYWORD",
+                "type_hint": "builtins.int",
+            },
+        ],
+        "return_value": "builtins.int",
+    }
+
+    node_func = NodeFunction.from_dict(node_func_dict)
+
+    assert node_func.func == dummy_func_w_all_param_types
+    assert len(node_func.parameters) == 6
+
+    pos_only, arg_a, arg_b, args, kw_only, kwargs = node_func.parameters
+    assert isinstance(pos_only, Argument)
+    assert pos_only.name == "pos_only"
+    assert pos_only.kind == Parameter.POSITIONAL_ONLY
+    assert pos_only.type_hint is int
+
+    assert isinstance(arg_a, Argument)
+    assert arg_a.name == "a"
+    assert arg_a.kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert arg_a.type_hint is int
+
+    assert isinstance(arg_b, Argument)
+    assert arg_b.name == "b"
+    assert arg_b.kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert arg_b.type_hint is int
+
+    assert isinstance(args, Argument)
+    assert args.name == "args"
+    assert args.kind == Parameter.VAR_POSITIONAL
+    assert args.type_hint is int
+
+    assert isinstance(kw_only, Argument)
+    assert kw_only.name == "kw_only"
+    assert kw_only.kind == Parameter.KEYWORD_ONLY
+    assert kw_only.type_hint is int
+
+    assert isinstance(kwargs, Argument)
+    assert kwargs.name == "kwargs"
+    assert kwargs.kind == Parameter.VAR_KEYWORD
+    assert kwargs.type_hint is int
+
+    assert node_func.return_value is int


### PR DESCRIPTION
Makes it possible to inspect kedro node in a way that allows conversion to dictionary and re-creation from dictionary.