### PR TITLE
[fix] make node json serialisable

### DIFF
--- a/src/kedro_inspect/node.py
+++ b/src/kedro_inspect/node.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 class InspectedNodeDict(TypedDict):
     name: str | None
-    tags: Set[str]
+    tags: List[str]
     confirms: List[str]
     namespace: str | None
     inputs: List[str] | Dict[str, str] | str | None
@@ -49,7 +49,7 @@ class InspectedNode:
     def to_dict(self) -> InspectedNodeDict:
         return {
             "name": self.name,
-            "tags": self.tags,
+            "tags": list(self.tags),
             "confirms": self.confirms,
             "namespace": self.namespace,
             "inputs": self.inputs,
@@ -62,7 +62,7 @@ class InspectedNode:
     def from_dict(cls, dct: InspectedNodeDict) -> Self:
         return cls(
             name=dct["name"],
-            tags=dct["tags"],
+            tags=set(dct["tags"]),
             confirms=dct["confirms"],
             namespace=dct["namespace"],
             inputs=dct["inputs"],

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,7 +1,10 @@
+import json
+
 from kedro.pipeline import node
+from typing_extensions import Any
+
 from kedro_inspect.node import InspectedNode
 from kedro_inspect.node_func import NodeFunction
-from typing_extensions import Any
 
 
 def identity(x) -> Any:
@@ -29,7 +32,7 @@ def test_inspected_node() -> None:
     inspected_node_dict = inspected_node.to_dict()
     assert inspected_node_dict == {
         "name": None,
-        "tags": set(),
+        "tags": [],
         "confirms": [],
         "namespace": None,
         "inputs": ["a"],
@@ -40,3 +43,5 @@ def test_inspected_node() -> None:
 
     inspected_node_from_dict = InspectedNode.from_dict(inspected_node_dict)
     assert inspected_node_from_dict.to_dict() == inspected_node_dict
+
+    assert json.loads(json.dumps(inspected_node_dict)) == inspected_node_dict


### PR DESCRIPTION
Without these changes, we cannot directly dump a NodeDict using `json`.