### PR TITLE
add cli command to dump json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,8 @@ classifiers = [
 dependencies = ["kedro", "typing-extensions"]
 dynamic = ["version"]
 
+[project.scripts]
+kedro-inspect = "kedro_inspect.cli:main"
+
 [tool.setuptools.dynamic]
 version = { attr = "kedro_inspect.__version__" }

--- a/src/kedro_inspect/cli.py
+++ b/src/kedro_inspect/cli.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Type
+
+from kedro.framework.project import pipelines
+from kedro.framework.startup import bootstrap_project
+
+from kedro_inspect.pipeline import InspectedPipeline
+
+
+class CliArgs(argparse.Namespace):
+    """Used to typehint parsed CLI arguments."""
+
+    project_path: Path
+    pipeline: str
+    indent: int | None
+    output: Path | None
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inspect a Kedro pipeline.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("project_path", type=Path, help="path to the Kedro project")
+    parser.add_argument(
+        "-p",
+        "--pipeline",
+        type=str,
+        help="name of the pipeline to inspect",
+        default="__default__",
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, help="path to the output file", required=False
+    )
+    parser.add_argument(
+        "--indent", type=int, help="indentation for JSON output", default=None
+    )
+    return parser
+
+
+def validate_args_before_bootstrap(args: Type[CliArgs]) -> None:
+    if not args.project_path.is_dir():
+        raise ValueError(f"Project path {args.project_path} is not a directory.")
+    if not args.project_path.exists():
+        raise ValueError(f"Project path {args.project_path} does not exist.")
+    if args.output is not None and args.output.exists():
+        raise ValueError(f"Output path {args.output} already exists.")
+
+
+def validate_args_after_bootstrap(args: Type[CliArgs]) -> None:
+    if args.pipeline not in pipelines:
+        raise ValueError(
+            f"Pipeline {args.pipeline} not found. "
+            f"Available pipelines: {list(pipelines)}"
+        )
+
+
+def main() -> int:
+    parser = get_parser()
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        return 1
+
+    args = parser.parse_args(namespace=CliArgs)
+    validate_args_before_bootstrap(args)
+
+    path = args.project_path.resolve()
+    _ = bootstrap_project(path)
+    validate_args_after_bootstrap(args)
+
+    pipe = pipelines[args.pipeline]
+    inspected = InspectedPipeline.from_kedro_pipeline(pipe)
+    js = json.dumps(inspected.to_dict(), indent=args.indent)
+    if args.output:
+        Path(args.output).write_text(js)
+    else:
+        print(js)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kedro_inspect/node.py
+++ b/src/kedro_inspect/node.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 class InspectedNodeDict(TypedDict):
     name: str | None
-    tags: Set[str]
+    tags: List[str]
     confirms: List[str]
     namespace: str | None
     inputs: List[str] | Dict[str, str] | str | None
@@ -49,7 +49,7 @@ class InspectedNode:
     def to_dict(self) -> InspectedNodeDict:
         return {
             "name": self.name,
-            "tags": self.tags,
+            "tags": list(self.tags),
             "confirms": self.confirms,
             "namespace": self.namespace,
             "inputs": self.inputs,
@@ -62,7 +62,7 @@ class InspectedNode:
     def from_dict(cls, dct: InspectedNodeDict) -> Self:
         return cls(
             name=dct["name"],
-            tags=dct["tags"],
+            tags=set(dct["tags"]),
             confirms=dct["confirms"],
             namespace=dct["namespace"],
             inputs=dct["inputs"],

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,7 +1,10 @@
+import json
+
 from kedro.pipeline import node
+from typing_extensions import Any
+
 from kedro_inspect.node import InspectedNode
 from kedro_inspect.node_func import NodeFunction
-from typing_extensions import Any
 
 
 def identity(x) -> Any:
@@ -29,7 +32,7 @@ def test_inspected_node() -> None:
     inspected_node_dict = inspected_node.to_dict()
     assert inspected_node_dict == {
         "name": None,
-        "tags": set(),
+        "tags": [],
         "confirms": [],
         "namespace": None,
         "inputs": ["a"],
@@ -40,3 +43,5 @@ def test_inspected_node() -> None:
 
     inspected_node_from_dict = InspectedNode.from_dict(inspected_node_dict)
     assert inspected_node_from_dict.to_dict() == inspected_node_dict
+
+    assert json.loads(json.dumps(inspected_node_dict)) == inspected_node_dict


### PR DESCRIPTION
Introduce a command, `kedro-inspect`, that loads a pipeline from a Kedro project and dumps it as json. 